### PR TITLE
Centralize dashboard color palette in dashboard_theme.py

### DIFF
--- a/dashboard_theme.py
+++ b/dashboard_theme.py
@@ -1,0 +1,34 @@
+"""Centralized color settings for the dashboard charts.
+
+Edit values here to update the dashboard color palette globally.
+"""
+
+DASHBOARD_COLORS = {
+    "categorical": [
+        "#4F46E5",  # indigo
+        "#0EA5E9",  # sky
+        "#14B8A6",  # teal
+        "#22C55E",  # green
+        "#F59E0B",  # amber
+        "#F97316",  # orange
+        "#EF4444",  # red
+        "#A855F7",  # purple
+    ],
+    "continuous_scale": "Blues",
+    "heatmap_scale": "Blues",
+    "qualitative_fallback": [
+        "#60A5FA",
+        "#34D399",
+        "#FBBF24",
+        "#F87171",
+        "#A78BFA",
+        "#22D3EE",
+    ],
+    "dark": {
+        "template": "plotly_dark",
+        "paper_bg": "#111111",
+        "plot_bg": "#111111",
+        "font": "white",
+        "grid": "gray",
+    },
+}

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -3,6 +3,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly_calplot import calplot
 from config import settings
+from dashboard_theme import DASHBOARD_COLORS
 import streamlit as st
 import plotly.express as px
 
@@ -144,7 +145,7 @@ with right:
         values='count',
         title='Not Done Percentage',
         hole=0.3,
-        color_discrete_sequence=px.colors.cmocean.balance
+        color_discrete_sequence=DASHBOARD_COLORS["categorical"]
     )
     fig.update_layout(
         title_x=0.3,  
@@ -165,7 +166,7 @@ with left:
         values='count',
         title="Done Tasks by List",
         hole=0.3,
-        color_discrete_sequence=px.colors.cmocean.balance
+        color_discrete_sequence=DASHBOARD_COLORS["categorical"]
     )
 
     fig.update_layout(
@@ -204,7 +205,7 @@ with left:
         x='Day',
         y='Tasks Completed',
         color='Tasks Completed',
-        color_continuous_scale='Blues',
+        color_continuous_scale=DASHBOARD_COLORS["continuous_scale"],
         text='Tasks Completed',
         title='Tasks-Day Distribution'
     )
@@ -377,7 +378,7 @@ fig = calplot(
     y="count",
     dark_theme=True,
     title="Pending Tasks Due Dates",
-    colorscale= "blues",
+    colorscale=DASHBOARD_COLORS["heatmap_scale"],
     month_lines= False,
     start_month= calplot_start_date.month,
     end_month= calplot_end_date.month
@@ -414,7 +415,7 @@ if due_source_col:
     counts[due_source_col] = counts[due_source_col].fillna('No Due Cards')
     counts['count'] = counts['count'].fillna(0).astype(int)
 
-    color_palette = px.colors.qualitative.Safe
+    color_palette = DASHBOARD_COLORS["qualitative_fallback"]
     source_values = counts[due_source_col].dropna().unique()
     color_map = {
         source: color_palette[idx % len(color_palette)]
@@ -452,10 +453,10 @@ else:
     ])
 
 fig.update_layout(
-    template='plotly_dark',
-    paper_bgcolor='#111111',
-    plot_bgcolor='#111111',
-    font=dict(color='white'),
+    template=DASHBOARD_COLORS["dark"]["template"],
+    paper_bgcolor=DASHBOARD_COLORS["dark"]["paper_bg"],
+    plot_bgcolor=DASHBOARD_COLORS["dark"]["plot_bg"],
+    font=dict(color=DASHBOARD_COLORS["dark"]["font"]),
     height=len(counts) * 20,
     legend_title_text='List'
 )
@@ -470,7 +471,7 @@ fig.update_yaxes(
     tickvals=counts['card_due'],
     ticktext=counts['card_due'].dt.strftime('%d %b'),
     showgrid=True,
-    gridcolor='gray'
+    gridcolor=DASHBOARD_COLORS["dark"]["grid"]
 )
 
 # Reverse order (latest on top)
@@ -488,7 +489,7 @@ for _, row in daily_totals.iterrows():
             text=str(int(row['count'])),
             showarrow=False,
             xanchor='left',
-            font=dict(color='white')
+            font=dict(color=DASHBOARD_COLORS["dark"]["font"])
         )
     )
 


### PR DESCRIPTION
### Motivation
- Ensure consistent, easily-editable color styling across all dashboard visualizations by moving palette and dark-theme values into a single config.
- Replace scattered hardcoded color values so future palette updates require changing only one file.

### Description
- Added a new `dashboard_theme.py` that defines `DASHBOARD_COLORS` with keys `categorical`, `continuous_scale`, `heatmap_scale`, `qualitative_fallback`, and `dark` for theme settings.
- Updated `pages/dashboard.py` to import `DASHBOARD_COLORS` and use it for pie charts, bar charts (`color_continuous_scale`), calplot heatmaps (`colorscale`), the fallback qualitative palette for stacked bars, and dark layout/annotation colors.
- Replaced inline color literals (e.g. `'Blues'`, `px.colors...`, `'#111111'`, `'white'`, `'gray'`) with references to the centralized config.

### Testing
- Ran `python -m compileall pages/dashboard.py dashboard_theme.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f294194483209baf170ed59a5c2b)