### PR TITLE
Add remote due-date editing for pending Trello tasks in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ streamlit run app.py
 
 3. Open the local URL shown in the terminal (usually `http://localhost:8501`).
 
+4. (Optional) Update due dates remotely from the app:
+   - Open **Dashboard** → **"🔧 Update Trello Due Date (Remote)"**.
+   - Select a pending task, choose a date, and click update.
+   - Refresh local CSVs:
+   ```bash
+   python fetch_trello_data.py
+   python data_processing.py
+   ```
+
 ## Project Structure
 
 ```text

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -6,6 +6,7 @@ from config import settings
 from dashboard_theme import DASHBOARD_COLORS
 import streamlit as st
 import plotly.express as px
+from trello_client import update_card_due_date
 
 st.set_page_config(
     page_title="Task Analytics Dashboard",
@@ -41,6 +42,43 @@ total_tasks, completed_tasks, pending_tasks, completion_rate = compute_metrics(d
 
 st.title("📊 Task Analytics Dashboard")
 st.caption(f"**Period:** {start_date} to {end_date}")
+
+with st.expander("🔧 Update Trello Due Date (Remote)", expanded=False):
+    pending_cards_df = (
+        df[df["status"] == "Not Done"][["card", "card_id", "list", "card_due"]]
+        .dropna(subset=["card_id"])
+        .sort_values(by=["list", "card"])
+    )
+
+    if pending_cards_df.empty:
+        st.info("No pending tasks with card IDs were found.")
+    else:
+        task_label_map = {
+            f"{row.card} ({row.list})": row.card_id
+            for row in pending_cards_df.itertuples(index=False)
+        }
+        selected_label = st.selectbox(
+            "Choose pending task",
+            options=list(task_label_map.keys()),
+            key="due_update_task_selector"
+        )
+        selected_due = st.date_input(
+            "New due date",
+            value=pd.Timestamp.today().date(),
+            key="due_update_date_input"
+        )
+
+        if st.button("Update due date in Trello", type="primary"):
+            selected_card_id = task_label_map[selected_label]
+            try:
+                update_card_due_date(selected_card_id, selected_due)
+                st.success(
+                    "Due date updated in Trello. Run data refresh "
+                    "(`python fetch_trello_data.py` then `python data_processing.py`) "
+                    "to sync local CSV files."
+                )
+            except Exception as exc:
+                st.error(f"Could not update due date: {exc}")
 
 col1, col2, col3= st.columns(3)
 

--- a/trello_client.py
+++ b/trello_client.py
@@ -1,0 +1,38 @@
+from datetime import date, datetime, time, timezone
+
+import requests
+from dotenv import dotenv_values
+
+
+env_values = dotenv_values("./app.env")
+API_KEY = env_values.get("TRELLO_API_KEY")
+API_TOKEN = env_values.get("TRELLO_API_TOKEN")
+
+
+def update_card_due_date(card_id: str, due_date: date) -> None:
+    """
+    Update Trello card due date using Trello REST API.
+
+    Raises ValueError for invalid configuration/input and RuntimeError for API failures.
+    """
+    if not API_KEY or not API_TOKEN:
+        raise ValueError("Missing Trello API credentials in app.env")
+
+    if not card_id:
+        raise ValueError("Card ID is required")
+
+    due_dt = datetime.combine(due_date, time.min).replace(tzinfo=timezone.utc)
+    due_value = due_dt.isoformat().replace("+00:00", "Z")
+
+    url = f"https://api.trello.com/1/cards/{card_id}"
+    params = {
+        "key": API_KEY,
+        "token": API_TOKEN,
+        "due": due_value,
+    }
+
+    response = requests.put(url, params=params, timeout=30)
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Trello API error ({response.status_code}): {response.text[:300]}"
+        )


### PR DESCRIPTION
### Motivation
- Provide an in-app way to update Trello card due dates so users can change deadlines from the dashboard without opening the Trello website.
- Make the dashboard actionable for pending tasks and reduce context-switching when adjusting schedules.

### Description
- Added `trello_client.py` with `update_card_due_date(card_id, due_date)` which reads `TRELLO_API_KEY`/`TRELLO_API_TOKEN` from `app.env` and calls Trello's `PUT /1/cards/{card_id}` endpoint to set the `due` field.
- Added a Dashboard expander `"🔧 Update Trello Due Date (Remote)"` in `pages/dashboard.py` that lists pending tasks (with `card_id`), lets the user pick a date, and calls `update_card_due_date` with success/error feedback.
- Updated `README.md` with brief usage steps describing the remote update UI and recommended local data refresh steps (`python fetch_trello_data.py` and `python data_processing.py`) after making changes.

### Testing
- Compiled changed modules with `python -m compileall pages/dashboard.py trello_client.py fetch_trello_data.py data_processing.py` and the compilation completed successfully.
- Re-compiled `pages/dashboard.py` and `trello_client.py` with `python -m compileall pages/dashboard.py trello_client.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ce601bc48320b55569b807a5ff5b)