### PR TITLE
Add 'Tasks Due Today' table to dashboard

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -432,6 +432,36 @@ fig.update_layout(
 )
 st.plotly_chart(fig, use_container_width=False)
 
+# Tasks due today table
+st.subheader("Tasks Due Today")
+
+today_start = pd.Timestamp.now(tz="UTC").normalize()
+today_end = today_start + pd.Timedelta(days=1)
+
+pending_due_today = pending_df.copy()
+pending_due_today['card_due'] = pd.to_datetime(
+    pending_due_today['card_due'],
+    errors='coerce',
+    utc=True
+)
+pending_due_today = pending_due_today[
+    (pending_due_today['card_due'] >= today_start) &
+    (pending_due_today['card_due'] < today_end)
+]
+
+if not pending_due_today.empty:
+    st.dataframe(
+        pending_due_today[['card', 'list', 'card_due']]
+        .rename(columns={
+            'card': 'Task Name',
+            'list': 'List',
+            'card_due': 'Due Date'
+        }),
+        use_container_width=True
+    )
+else:
+    st.info("No tasks are due today.")
+
 df = pending_df.copy()
 due_source_col = 'list' if 'list' in df.columns else None
 


### PR DESCRIPTION
### Motivation
- Provide a quick, visible list of pending tasks that are due within the current UTC day directly on the analytics dashboard.

### Description
- Add a new `Tasks Due Today` section in `pages/dashboard.py` that computes `today_start` and `today_end` using `pd.Timestamp.now(tz="UTC").normalize()` and filters `pending_df` for `card_due` values within that UTC range.
- Parse `card_due` as timezone-aware datetimes with `pd.to_datetime(..., utc=True)`, then display a table with `Task Name`, `List`, and `Due Date` using `st.dataframe` when any matches are found.
- Show an informational message `"No tasks are due today."` when there are no matching pending tasks.

### Testing
- Successfully ran `python -m py_compile pages/dashboard.py` to verify the module compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e522988ef08320a5a1cc141b8863b4)